### PR TITLE
Correct File Variables for Emacs

### DIFF
--- a/color.h
+++ b/color.h
@@ -64,6 +64,11 @@ static const uint32_t color_list[256] = {
     0xA8A8A8, 0xB2B2B2, 0xBCBCBC, 0xC6C6C6, 0xD0D0D0, 0xDADADA, 0xE4E4E4, 0xEEEEEE,
 };
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/dcs.c
+++ b/dcs.c
@@ -634,6 +634,11 @@ void decdld_parse_header(struct terminal *term, char *start_buf)
     decdld_parse_data(cp + 1, start_char, term->drcs[charset]); /* skil final char */
 }
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/dcs.h
+++ b/dcs.h
@@ -20,6 +20,11 @@
 void sixel_parse_header(struct terminal *term, char *start_buf);
 void decdld_parse_header(struct terminal *term, char *start_buf);
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/function.c
+++ b/function.c
@@ -484,6 +484,11 @@ void clear_tabstop(struct terminal *term, struct parm_t *parm)
     }
 }
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/function.h
+++ b/function.h
@@ -60,6 +60,11 @@ void reset_mode(struct terminal *term, struct parm_t *parm);
 void set_margin(struct terminal *term, struct parm_t *parm);
 void clear_tabstop(struct terminal *term, struct parm_t *parm);
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/main.c
+++ b/main.c
@@ -610,6 +610,11 @@ int main(int argc, char *argv[])
     return nret;
 }
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/malloc_stub.c
+++ b/malloc_stub.c
@@ -54,6 +54,11 @@ rpl_realloc(void *p, size_t n)
 }
 #endif /* !HAVE_REALLOC */
 
-/* Hello emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/malloc_stub.h
+++ b/malloc_stub.h
@@ -32,6 +32,11 @@ void * rpl_realloc(void *p, size_t n);
 
 #endif /* MALLOC_STUB_H */
 
-/* Hello emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/parse.c
+++ b/parse.c
@@ -331,6 +331,11 @@ void parse(struct terminal *term, uint8_t *buf, int size, int *pdirty)
     }
 }
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/parse.h
+++ b/parse.h
@@ -19,6 +19,11 @@
 /* ctr char/esc sequence/charset function */
 void parse(struct terminal *term, uint8_t *buf, int size, int *pdirty);
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/pseudo.c
+++ b/pseudo.c
@@ -121,6 +121,11 @@ void refresh(struct pseudobuffer *pb, struct terminal *term)
     }
 }
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/pseudo.h
+++ b/pseudo.h
@@ -26,6 +26,11 @@ struct pseudobuffer {
 
 void refresh(struct pseudobuffer *pb, struct terminal *term);
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/terminal.c
+++ b/terminal.c
@@ -436,6 +436,11 @@ void term_die(struct terminal *term)
     free(term->sixel.bitmap);
 }
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/terminal.h
+++ b/terminal.h
@@ -37,6 +37,11 @@ void term_init(struct terminal *term, int width, int height,
                int cursor_color, int tabwidth, int cjkwidth);
 void term_die(struct terminal *term);
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/util.c
+++ b/util.c
@@ -184,6 +184,11 @@ int hex2num(char *str)
     return estrtol(str, NULL, 16);
 }
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/util.h
+++ b/util.h
@@ -35,6 +35,11 @@ int my_ceil(int val, int div);
 int dec2num(char *str);
 int hex2num(char *str);
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/wcwidth.h
+++ b/wcwidth.h
@@ -23,6 +23,11 @@
 int mk_wcwidth(wchar_t ucs);
 int mk_wcwidth_cjk(wchar_t ucs);
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */

--- a/yaft.h
+++ b/yaft.h
@@ -191,6 +191,11 @@ struct parm_t { /* for parse_arg() */
     char *argv[MAX_ARGS];
 };
 
-/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
+/* emacs Local Variables:      */
+/* emacs mode: c               */
+/* emacs tab-width: 4          */
+/* emacs indent-tabs-mode: nil */
+/* emacs c-basic-offset: 4     */
+/* emacs End:                  */
 /* vim: set expandtab ts=4 : */
 /* EOF */


### PR DESCRIPTION
現状では、Emacs に対するタブ幅・インデントなどの設定が、ファイル末尾に以下の形式で指定されています。

```
/* emacs, -*- Mode: C; tab-width: 4; indent-tabs-mode: nil -*- */
```

しかし、この形式の指定は先頭行にないと Emacs に認識されず、このままでは勿体ないです。ファイル末尾で Emacs に認識させるためには [GNU Emacs Manual: Specifying File Variables](https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html) にある Local Variables の指定を用いる必要があります:

```
PREFIX Local Variables: SUFFIX
PREFIX mode: c          SUFFIX
PREFIX ...略...         SUFFIX
PREFIX End:             SUFFIX
```

(ただし `PREFIX`, `SUFFIX` は何らかの共通の文字列)。

また、`c-basic-offset: 4` は、インデント量を 4 に明示するものです (Emacs default は 2)。

この pull request は上記のような書き換えです。(代わりに `-*- ～ -*-` の指定を先頭行に移動するという書き換えも考えられます。)
