### PR TITLE
Modify time scheduling

### DIFF
--- a/main.c
+++ b/main.c
@@ -373,9 +373,15 @@ static int parse_args(int argc, char *argv[], struct settings_t *psettings)
             break;
         case 'I':
             psettings->render_interval = atoi(optarg);
+            if (psettings->render_interval < 0) {
+                goto argerr;
+            }
             break;
         case 's':
             psettings->play_speed = atof(optarg);
+            if (psettings->play_speed <= 0.0) {
+                goto argerr;
+            }
             break;
         default:
             goto argerr;

--- a/main.c
+++ b/main.c
@@ -250,15 +250,10 @@ static void show_help()
            );
 }
 
-enum seq2gif_optflags {
-    seq2gif_optflag_render_interval = 0x1001,
-    seq2gif_optflag_play_speed      = 's',
-};
-
 static int parse_args(int argc, char *argv[], struct settings_t *psettings)
 {
     int n;
-    char const *optstring = "w:h:HVl:f:b:c:t:jr:i:o:s:";
+    char const *optstring = "w:h:HVl:f:b:c:t:jr:i:o:I:s:";
 #ifdef HAVE_GETOPT_LONG
     int long_opt;
     int option_index;
@@ -276,8 +271,8 @@ static int parse_args(int argc, char *argv[], struct settings_t *psettings)
         {"output",            required_argument,  &long_opt, 'o'},
         {"help",              no_argument,        &long_opt, 'H'},
         {"version",           no_argument,        &long_opt, 'V'},
-        {"render-interval",   required_argument,  &long_opt, seq2gif_optflag_render_interval},
-        {"play-speed",        required_argument,  &long_opt, seq2gif_optflag_play_speed},
+        {"render-interval",   required_argument,  &long_opt, 'I'},
+        {"play-speed",        required_argument,  &long_opt, 's'},
         {0, 0, 0, 0}
     };
 #endif  /* HAVE_GETOPT_LONG */
@@ -377,10 +372,10 @@ static int parse_args(int argc, char *argv[], struct settings_t *psettings)
         case 'V':
             psettings->show_version = 1;
             break;
-        case seq2gif_optflag_render_interval:
+        case 'I':
             psettings->render_interval = atoi(optarg);
             break;
-        case seq2gif_optflag_play_speed:
+        case 's':
             psettings->play_speed = atof(optarg);
             break;
         default:

--- a/main.c
+++ b/main.c
@@ -70,6 +70,9 @@ struct settings_t {
     int repeat;
     char *input;
     char *output;
+
+    int render_interval;
+    double play_speed;
 };
 
 enum cmap_bitfield {
@@ -238,13 +241,24 @@ static void show_help()
             "                                      if '-' is given. (default: '-')\n"
             "-V, --version                         show version and license information.\n"
             "-H, --help                            show this help.\n"
+            "--render-interval=DELAY               skip frames with smaller delays than\n"
+            "                                      DELAY specified in milliseconds.\n"
+            "                                      (default: 20)\n"
+            "-s NUM, --play-speed=NUM              specify the factor of the play speed.\n"
+            "                                      A larger value means faster play.\n"
+            "                                      (default: 1.0)\n"
            );
 }
+
+enum seq2gif_optflags {
+    seq2gif_optflag_render_interval = 0x1001,
+    seq2gif_optflag_play_speed      = 's',
+};
 
 static int parse_args(int argc, char *argv[], struct settings_t *psettings)
 {
     int n;
-    char const *optstring = "w:h:HVl:f:b:c:t:jr:i:o:";
+    char const *optstring = "w:h:HVl:f:b:c:t:jr:i:o:s:";
 #ifdef HAVE_GETOPT_LONG
     int long_opt;
     int option_index;
@@ -262,6 +276,8 @@ static int parse_args(int argc, char *argv[], struct settings_t *psettings)
         {"output",            required_argument,  &long_opt, 'o'},
         {"help",              no_argument,        &long_opt, 'H'},
         {"version",           no_argument,        &long_opt, 'V'},
+        {"render-interval",   required_argument,  &long_opt, seq2gif_optflag_render_interval},
+        {"play-speed",        required_argument,  &long_opt, seq2gif_optflag_play_speed},
         {0, 0, 0, 0}
     };
 #endif  /* HAVE_GETOPT_LONG */
@@ -360,6 +376,12 @@ static int parse_args(int argc, char *argv[], struct settings_t *psettings)
             break;
         case 'V':
             psettings->show_version = 1;
+            break;
+        case seq2gif_optflag_render_interval:
+            psettings->render_interval = atoi(optarg);
+            break;
+        case seq2gif_optflag_play_speed:
+            psettings->play_speed = atof(optarg);
             break;
         default:
             goto argerr;
@@ -484,6 +506,10 @@ int main(int argc, char *argv[])
     int gifsize, colormap[COLORS * BYTES_PER_PIXEL + 1];
     unsigned char *img;
 
+    uint32_t gif_unit_time;
+    uint32_t gif_render_interval;
+    int is_render_deferred;
+
     struct settings_t settings = {
         80,     /* width */
         24,     /* height */
@@ -498,6 +524,9 @@ int main(int argc, char *argv[])
         0,      /* repeat */
         NULL,   /* input */
         NULL,   /* output */
+
+        20,     /* render_interval */
+        1.0,    /* play_speed */
     };
 
     if (parse_args(argc, argv, &settings) != 0) {
@@ -544,6 +573,9 @@ int main(int argc, char *argv[])
     prev = now = readtime(in_file, obuf);
 
     /* main loop */
+    gif_unit_time = (int)(10000 * settings.play_speed);
+    gif_render_interval = settings.render_interval / 10;
+    is_render_deferred = 0;
     for(;;) {
         len = readlen(in_file, obuf);
         if (len <= 0) {
@@ -559,23 +591,41 @@ int main(int argc, char *argv[])
             nret = EXIT_FAILURE;
             break;
         }
+
         parse(&term, obuf, nread, &dirty);
         now = readtime(in_file, obuf);
         if (now == -1) {
             break;
         }
+
         if (term.esc.state != STATE_DCS || dirty) {
             refresh(&pb, &term);
-            delay = now - prev;
+            delay = (now - prev) / gif_unit_time;
+
+            if (is_render_deferred && delay > gif_render_interval) {
+                controlgif(gsdata, -1, gif_render_interval, 0, 0);
+                prev += gif_render_interval * gif_unit_time;
+                putgif(gsdata, img);
+                delay -= gif_render_interval;
+            }
 
             /* take screenshot */
             apply_colormap(&pb, img);
-            controlgif(gsdata, -1, delay / 10000, 0, 0);
-            prev = now;
-            putgif(gsdata, img);
+            is_render_deferred = delay < gif_render_interval;
+            if (!is_render_deferred) {
+                controlgif(gsdata, -1, delay, 0, 0);
+                prev = now;
+                putgif(gsdata, img);
+            }
         }
         dirty = 0;
     }
+
+    if (is_render_deferred) {
+        controlgif(gsdata, -1, gif_render_interval, 0, 0);
+        putgif(gsdata, img);
+    }
+
     if (settings.last_frame_delay > 0) {
         controlgif(gsdata, -1, settings.last_frame_delay / 10, 0, 0);
         putgif(gsdata, img);

--- a/main.c
+++ b/main.c
@@ -568,7 +568,7 @@ int main(int argc, char *argv[])
     prev = now = readtime(in_file, obuf);
 
     /* main loop */
-    gif_unit_time = (int)(10000 * settings.play_speed);
+    gif_unit_time = (uint32_t)(10000 * settings.play_speed);
     gif_render_interval = settings.render_interval / 10;
     is_render_deferred = 0;
     for(;;) {

--- a/main.c
+++ b/main.c
@@ -70,7 +70,6 @@ struct settings_t {
     int repeat;
     char *input;
     char *output;
-
     int render_interval;
     double play_speed;
 };
@@ -500,7 +499,6 @@ int main(int argc, char *argv[])
     unsigned char *gifimage = NULL;
     int gifsize, colormap[COLORS * BYTES_PER_PIXEL + 1];
     unsigned char *img;
-
     uint32_t gif_unit_time;
     uint32_t gif_render_interval;
     int is_render_deferred;
@@ -519,7 +517,6 @@ int main(int argc, char *argv[])
         0,      /* repeat */
         NULL,   /* input */
         NULL,   /* output */
-
         20,     /* render_interval */
         1.0,    /* play_speed */
     };


### PR DESCRIPTION
@saitoha 様、さきの pull request #2 の merge ありがとうございます。

開発が停止しているのかと思って、`seq2gif` をてもとで勝手に変更して使わせていただいていたのですが、これを機に項目毎に pull request させていただこうかと考えているのですが構わないでしょうか。
## 問題点

この pull request は「_短期間に flush を繰り返すようなコマンド_の出力から animated GIF を生成してブラウザで表示すると、とてつもなくアニメーション速度が遅くなってしまう」という現象に対するものです。例として以下を御覧下さい。

``` sh
ttyrec -e 'for i in {1..10000}; do printf "\r%s" $i; done; echo' loop
./seq2gif-master -w 10 -h 2 < loop > loop-master.gif
./seq2gif-play-speed -w 10 -h 2 < loop > loop-play-speed.gif
```

1 行目のコマンドは一瞬で完了しますが、その間に `loop` (ttyrecord ファイル) に大量のエントリを追加します。これを元に生成した animated GIFs を以下に添付します。
修正前 (seq2gif-master) ![loop-master](https://cloud.githubusercontent.com/assets/8982192/17145525/65082ad8-5395-11e6-8529-4333a1bf0024.gif) / 修正後 (seq2gif-play-speed) ![loop-play-speed](https://cloud.githubusercontent.com/assets/8982192/17145534/6f9a2384-5395-11e6-988e-4a53f8c1dae7.gif)

実際の実行は一瞬であるにもかかわらず "修正前" の animated GIF は再生がとても遅くなっています。期待する動作は、"修正後" の animated GIF のようなものです。ここに載せた例は作為的なものですが、実際の利用でこのことが問題になったのでここで報告させて頂きます。
## 原因

原因は Chrome を初めとするすべてのブラウザで 0.02 sec よりも小さなフレームの遅延時間 (delay) を認識しないこと、および、認識できない場合の動作が原因です。(参考記事: [Nullsleep | Jeremiah Johnson - Animated GIF Minimum Frame Delay Browser Compatibility Study](http://nullsleep.tumblr.com/post/16524517190/animated-gif-minimum-frame-delay-browser) 2012年の記事ですが今でも状況は変わっていません。)

この delay の下限は、特に Internet Explorer や Safari では 0.06 s と大きな値になっています。さらに、ソフトウェアによっては下限が 0.10 sec のものもあるようです (Windows フォトビューワーなど)。また、認識できるよりも小さな delay を指定した場合、どのソフトウェアもフレームの delay は "0.10s" と長めに解釈するようです。このとき何が起こるかというと、例えば、0.01 sec のフレーム 100 枚で 1 秒間のアニメーションを作成してブラウザで表示させると 10 秒間かけてゆっくりと表示されることになります。

また、ttyrec は 0.01 sec よりも小さな時間間隔の更新に対応していますが、animated GIF ではこれらを表示できません。無闇にフレームを全出力しても、良ければファイルサイズが大きくなるだけ、悪いと delay 0 のフレームが delay 0.10 sec と解釈されて間延びした再生になります。
## 解決法

これを解決するために **最小の delay** を設定して、それより短い期間に起こる端末の状態変化は animated GIF に出力しないようにします。最小の delay を指定するためにオプションを追加しました。
- オプション `--render-interval=NUMBER`

このオプションでは最小のフレームの表示時間 (整数、単位: ミリ秒) を指定します。

既定値は 20 msec にしました。現状で、Web ページに載せるために animated gif を生成する場合、フレーム表示時間を 0.02 sec より小さくすることは意味がないとの考えです。また、ブラウザ以外のソフトウェアを考えるとしても、実際のディスプレイのリフレッシュレートで 60 Hz が一般的なので、やはり 0.02 sec が妥当なところなのではないかと考えています。

また、従来の動作はこの値を 0 に指定することで再現します。

他、従来の動作は 「_目にも止まらぬ速さの更新を遅くして端末の表示がどう変化していったかを可視化する_」 という効用もあったのかもしれないと思います。そういった目的のためにより自然な解決法として、一緒に再生速度のオプションも pull request に含めます。
- オプション `-s FACTOR, --play-speed=FACTOR`

`-s 0.5` とすると 2 倍遅く再生します。`-s 2` とすると 2 倍速く再生します。オプション名 `-s` は、`ttyrec` に附属の `ttyplay` を真似ました。このオプションは、端末の操作方法を説明するなどの目的で早回しする目的でも便利です。
## 確認事項

実は修正前の seq2gif でもこの問題を回避する方法があるなどということでしたらすみません。

また、`show_help()` で表示されるオプションの並び順がよく分かりませんでしたので、新規オプションの説明は末尾に追記させて頂きました。ご要望があれば適切な位置に挿入し直します。

その他、気になる点・アドバイスなどあればお知らせ下さい。名前付けセンスが拙いので、オプションの名称や変数名についても案があればお願いします。

よろしくおねがいいたします。
