### PR TITLE
Fix usage of the uninitialized variable long_opt

### DIFF
--- a/main.c
+++ b/main.c
@@ -248,9 +248,6 @@ static int parse_args(int argc, char *argv[], struct settings_t *psettings)
 #ifdef HAVE_GETOPT_LONG
     int long_opt;
     int option_index;
-#endif  /* HAVE_GETOPT_LONG */
-
-#ifdef HAVE_GETOPT_LONG
     struct option long_options[] = {
         {"width",             required_argument,  &long_opt, 'w'},
         {"height",            required_argument,  &long_opt, 'h'},

--- a/main.c
+++ b/main.c
@@ -243,10 +243,10 @@ static void show_help()
 
 static int parse_args(int argc, char *argv[], struct settings_t *psettings)
 {
-    int long_opt;
     int n;
     char const *optstring = "w:h:HVl:f:b:c:t:jr:i:o:";
 #ifdef HAVE_GETOPT_LONG
+    int long_opt;
     int option_index;
 #endif  /* HAVE_GETOPT_LONG */
 
@@ -280,9 +280,11 @@ static int parse_args(int argc, char *argv[], struct settings_t *psettings)
         if (n == -1) {
             break;
         }
+#ifdef HAVE_GETOPT_LONG
         if (n == 0) {
             n = long_opt;
         }
+#endif  /* HAVE_GETOPT_LONG */
         switch(n) {
         case 'w':
             psettings->width = atoi(optarg);


### PR DESCRIPTION
`!defined(HAVE_GETOPT_LONG)` のとき、`main.c` の関数 `parse_args` の局所変数 `int long_opt` が初期化・代入されないにもかかわらず、その値が参照されています。

実のところ `getopt` の戻り値が 0 になることはなさそうなのでこのままでも問題はなさそうですが、恐らく意図してのことではないと思い報告させて頂きます。
